### PR TITLE
Field Notes follow-ups: thumbnails on index, remove LinkedIn icon

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ github_username: chraibi
 # facebook_username: jekyll
 # flickr_username: jekyll
 # instagram_username: jameswgrant
-linkedin_username: mohcine-chraibi
+# linkedin_username: mohcine-chraibi
 # xing_username: jekyll
 # pinterest_username: jekyll
 youtube_username: "@pedestrianandfiredynamics7738"

--- a/_posts/2026-05-16-wolfheze-hamburg-munich.md
+++ b/_posts/2026-05-16-wolfheze-hamburg-munich.md
@@ -3,6 +3,7 @@ layout: post
 title: "Wolfheze, Hamburg, Munich"
 lead: "One intensely refreshing week across three communities."
 description: "A CROWDING project meeting in Wolfheze, a crowd management workshop at the Hamburg Harbour Birthday, and the VIB workshop in Munich — notes from a week on the road."
+thumb: /images/notes/2026-05-wolfheze-hamburg-munich/crowding-retreat.jpg
 ---
 
 Last week was an intensely refreshing one.

--- a/_posts/2026-06-12-why-dont-airlines-board-planes-the-optimal-way.md
+++ b/_posts/2026-06-12-why-dont-airlines-board-planes-the-optimal-way.md
@@ -4,6 +4,7 @@ title: "Why don't airlines board planes the optimal way?"
 lead: "The mathematically optimal boarding method has existed since 2008. We rebuilt the classic studies in JuPedSim to see why it stays on paper."
 description: "Steffen's optimal boarding method is dramatically faster in theory. A JuPedSim reproduction shows the optimum is also the most fragile: it collapses under low compliance, mixed passengers, and travel groups."
 linkedin: "https://www.linkedin.com/pulse/why-dont-airlines-board-planes-optimal-way-jupedsim-zijte/"
+thumb: /images/notes/2026-06-airplane-boarding/fig3.gif
 ---
 
 In 2008, astrophysicist Jason Steffen worked out the mathematically optimal way to board an airplane. It boards passengers in a precise interleaved order — window seats first, every other row — so that many people stow their luggage at the same time and nobody ever has to climb over a seated neighbor. In ideal conditions it's dramatically faster than how airlines actually do it. A counter-intuitive part of the result is that boarding back-to-front, which many airlines use, is no better than boarding everyone at random, and front-to-back is worse than random.

--- a/_posts/2026-06-29-why-do-roaming-crowds-drift-counterclockwise.md
+++ b/_posts/2026-06-29-why-do-roaming-crowds-drift-counterclockwise.md
@@ -4,6 +4,7 @@ title: "Why do roaming crowds drift counterclockwise — and where?"
 lead: "Testing the mechanism behind a curious experimental result with JuPedSim."
 description: "A Nature Communications paper reports that freely roaming crowds drift counterclockwise. We rebuilt the experiment in JuPedSim to test whether a slight individual left-turn bias explains it."
 linkedin: "https://www.linkedin.com/pulse/why-does-roaming-crowd-turn-counterclockwise-jupedsim-pptee/"
+thumb: /images/notes/2026-06-counterclockwise-crowd/fig1.gif
 ---
 
 <figure>

--- a/notes.md
+++ b/notes.md
@@ -11,6 +11,7 @@ description: "Short notes from the road — workshops, meetings, and things wort
 
 <style>
   .post-header { display: none; }
+  .post { max-width: 1100px !important; }
   .page-content { background: #fdfcf9; }
   .notes-index { font-family: "Newsreader", Georgia, serif; color: #26313b; padding: 2rem 0 3rem; }
   .notes-kicker {
@@ -26,16 +27,36 @@ description: "Short notes from the road — workshops, meetings, and things wort
   }
   .notes-intro { font-style: italic; font-size: 1.9rem; color: #55606b; margin: 1.2rem 0 0; line-height: 1.5; }
   .notes-list { list-style: none; margin: 3.5rem 0 0; padding: 0; }
-  .notes-list li { border-top: 1px solid #e3ddd2; padding: 2.2rem 0; margin: 0; }
+  .notes-list li { border-top: 1px solid #e3ddd2; margin: 0; }
   .notes-list li:last-child { border-bottom: 1px solid #e3ddd2; }
+  .note-row {
+    display: grid; grid-template-columns: 1fr 300px; gap: 3rem; align-items: center;
+    padding: 2.4rem 0; text-decoration: none; color: inherit; text-align: left;
+  }
   .note-item-date {
     font-family: Roboto, "Helvetica Neue", sans-serif;
     font-size: 1.2rem; color: #8b8577; letter-spacing: .08em; text-transform: uppercase;
   }
-  .note-item-title { margin: .4rem 0 0; font-size: 2.7rem; line-height: 1.2; font-weight: 500; }
-  .note-item-title a { color: #1c252e; text-decoration: none; }
-  .note-item-title a:hover { color: #477dca; }
-  .note-item-lead { font-style: italic; font-size: 1.75rem; color: #55606b; margin: .5rem 0 0; }
+  .note-item-title {
+    font-family: "Newsreader", Georgia, serif;
+    margin: .5rem 0 0; font-size: 2.9rem; line-height: 1.15; font-weight: 500;
+    color: #1c252e; transition: color .15s ease;
+  }
+  .note-row:hover .note-item-title { color: #477dca; }
+  .note-item-lead { font-style: italic; font-size: 1.75rem; color: #55606b; margin: .6rem 0 0; line-height: 1.45; }
+  .note-thumb {
+    width: 300px; aspect-ratio: 3 / 2; border-radius: 6px; overflow: hidden;
+    background: #f0ece3; border: 1px solid #e3ddd2;
+  }
+  .note-thumb img {
+    width: 100%; height: 100%; object-fit: cover; display: block;
+    transition: transform .3s ease;
+  }
+  .note-row:hover .note-thumb img { transform: scale(1.04); }
+  @media (max-width: 720px) {
+    .note-row { grid-template-columns: 1fr; gap: 1.4rem; }
+    .note-thumb { width: 100%; }
+  }
   .notes-back { font-family: Roboto, "Helvetica Neue", sans-serif; font-size: 1.3rem; margin-top: 3rem; }
   .notes-back a { color: #477dca; text-decoration: none; }
   .notes-back a:hover { text-decoration: underline; }
@@ -49,9 +70,16 @@ description: "Short notes from the road — workshops, meetings, and things wort
   <ul class="notes-list">
     {% for post in site.posts %}
     <li>
-      <span class="note-item-date">{{ post.date | date: "%B %-d, %Y" }}</span>
-      <h2 class="note-item-title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
-      {% if post.lead %}<p class="note-item-lead">{{ post.lead }}</p>{% endif %}
+      <a class="note-row" href="{{ post.url | relative_url }}">
+        <div>
+          <span class="note-item-date">{{ post.date | date: "%B %-d, %Y" }}</span>
+          <h2 class="note-item-title">{{ post.title }}</h2>
+          {% if post.lead %}<p class="note-item-lead">{{ post.lead }}</p>{% endif %}
+        </div>
+        {% if post.thumb %}
+        <div class="note-thumb"><img src="{{ post.thumb | relative_url }}" alt="" loading="lazy"></div>
+        {% endif %}
+      </a>
     </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
Two commits that were pushed to `field-notes` after PR #8 was already merged, so they never reached master:

- Remove the LinkedIn header icon so the icon row stays on one line
- Notes index: wider layout (1100px) with a thumbnail (figure/GIF from each post) right of the title, whole row clickable with hover effects

https://claude.ai/code/session_01JpdThcHLaL47zR5qYALSVk